### PR TITLE
Adding project badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # node-mysql
 
+[![view on npm](http://img.shields.io/npm/v/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/node-mysql)
+[![view on npm](http://img.shields.io/npm/l/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/operations/node-mysql)
+[![npm module downloads](http://img.shields.io/npm/dt/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/node-mysql)
+[![Dependencies Status](https://david-dm.org/redblaze/node-mysql.svg)](https://david-dm.org/redblaze/node-mysql)
+
 An enhancement to the mysql lib to make it a bit easier to use.  Based on the existing funtionalities of (npm) mysql, it also
 
 * Handles transactions.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # node-mysql
 
-[![view on npm](http://img.shields.io/npm/v/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/node-mysql)
-[![view on npm](http://img.shields.io/npm/l/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/operations/node-mysql)
-[![npm module downloads](http://img.shields.io/npm/dt/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/node-mysql)
+[![view on npm](http://img.shields.io/npm/v/node-mysql.svg)](https://www.npmjs.org/package/node-mysql)
+[![view on npm](http://img.shields.io/npm/l/node-mysql.svg)](https://www.npmjs.org/package/node-mysql)
+[![npm module downloads](http://img.shields.io/npm/dt/node-mysql.svg)](https://www.npmjs.org/package/node-mysql)
 [![Dependencies Status](https://david-dm.org/redblaze/node-mysql.svg)](https://david-dm.org/redblaze/node-mysql)
 
 An enhancement to the mysql lib to make it a bit easier to use.  Based on the existing funtionalities of (npm) mysql, it also


### PR DESCRIPTION
Project badges help users to figure out popularity, build stability, dependencies security, and are a great addition to the README to give a quick overview on the project status in general.
