### PR TITLE
Fix/package dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # node-mysql
 
+[![view on npm](http://img.shields.io/npm/v/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/node-mysql)
+[![view on npm](http://img.shields.io/npm/l/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/operations/node-mysql)
+[![npm module downloads](http://img.shields.io/npm/dt/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/node-mysql)
+[![Dependencies Status](https://david-dm.org/redblaze/node-mysql.svg)](https://david-dm.org/redblaze/node-mysql)
+
 An enhancement to the mysql lib to make it a bit easier to use.  Based on the existing funtionalities of (npm) mysql, it also
 
 * Handles transactions.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # node-mysql
 
-[![view on npm](http://img.shields.io/npm/v/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/node-mysql)
-[![view on npm](http://img.shields.io/npm/l/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/operations/node-mysql)
-[![npm module downloads](http://img.shields.io/npm/dt/operations-orchestration-crontab.svg)](https://www.npmjs.org/package/node-mysql)
+[![view on npm](http://img.shields.io/npm/v/node-mysql.svg)](https://www.npmjs.org/package/node-mysql)
+[![view on npm](http://img.shields.io/npm/l/node-mysql.svg)](https://www.npmjs.org/package/node-mysql)
+[![npm module downloads](http://img.shields.io/npm/dt/node-mysql.svg)](https://www.npmjs.org/package/node-mysql)
 [![Dependencies Status](https://david-dm.org/redblaze/node-mysql.svg)](https://david-dm.org/redblaze/node-mysql)
 
 An enhancement to the mysql lib to make it a bit easier to use.  Based on the existing funtionalities of (npm) mysql, it also

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
         ]
     },
     "dependencies": {
-        "better-js-class": "*",
-        "cps": "*",
-        "mysql": "*",
-        "underscore": "*"
+        "better-js-class": "~0.1.3",
+        "cps": "~1.0.2",
+        "mysql": "~2.10.2",
+       "underscore": "~1.8.3"
     }
 }


### PR DESCRIPTION
Updating dependencies for current stable versions of packages.
It's usually a best practice to specify a version for compatibility and avoiding breaking changes coming in from dependencies. Also `*` will install unstable versions of packages, so if the latest is required it's best to specify `latest`.
